### PR TITLE
Remove gallery, demos, and Twitter icons

### DIFF
--- a/Padre 1.1.0/index.html
+++ b/Padre 1.1.0/index.html
@@ -25,11 +25,6 @@
                                 <ul class="list-inline social-list">
                                     <li>
                                         <a href="#">
-                                            <i class="ti-twitter-alt"></i>
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a href="#">
                                             <i class="ti-facebook"></i>
                                         </a>
                                     </li>
@@ -83,30 +78,7 @@
                                         <a href="#special" class="inner-link">Special</a>
                                     </li>
                                     <li>
-                                        <a href="#gallery" class="inner-link">Gallery</a>
-                                    </li>
-                                    <li>
                                         <a href="#contact" class="inner-link">Contact</a>
-                                    </li>
-                                    <li>
-                                        <div class="divider hidden-xs"></div>
-                                    </li>
-                                    <li class="has-dropdown">
-                                        <a href="#">Demos</a>
-                                        <ul class="text-left">
-                                            <li>
-                                                <a href="index.html">Classic</a>
-                                            </li>
-                                            <li>
-                                                <a href="index-contact-form.html">w/ Form</a>
-                                            </li>
-                                            <li>
-                                                <a href="index-instagram.html">Instagram</a>
-                                            </li>
-                                            <li>
-                                                <a href="index-fullwidth.html">Wide Header</a>
-                                            </li>
-                                        </ul>
                                     </li>
                                     <li>
                                         <a href="news.html">News</a>
@@ -426,28 +398,6 @@
                 </div>
                 <!--end of container-->
             </section>
-            <a id="gallery"></a>
-            <section class="pb0">
-                <div class="container">
-                    <div class="row  mb64 mb-xs-40">
-                        <div class="col-sm-12 text-center">
-                            <div class="ribbon">
-                                <h6 class="uppercase mb0">@padreco</h6>
-                            </div>
-                        </div>
-                    </div>
-                    <!--end of row-->
-                    <div class="row">
-                        <div class="col-sm-12">
-                            <div class="instafeed grid-gallery" data-user-name="walkdontruncafe">
-                                <ul></ul>
-                            </div>
-                        </div>
-                    </div>
-                    <!--end of row-->
-                </div>
-                <!--end of container-->
-            </section>
             <a id="contact"></a>
             <section>
                 <div class="container">
@@ -509,11 +459,6 @@
                         <div class="col-md-3 col-md-offset-3 col-sm-4 col-sm-offset-2 text-center">
                             <h6 class="uppercase">Follow Us</h6>
                             <ul class="list-inline social-list">
-                                <li>
-                                    <a href="#">
-                                        <i class="ti-twitter-alt"></i>
-                                    </a>
-                                </li>
                                 <li>
                                     <a href="#">
                                         <i class="ti-facebook"></i>


### PR DESCRIPTION
## Summary
- clean up header social icons by dropping Twitter
- remove Gallery section and its link
- drop the Demos dropdown from navigation

No news section was present in the page.

## Testing
- `grep -n "ti-twitter-alt" -n "Padre 1.1.0/index.html"`